### PR TITLE
Fix issue where pressing Enter during Japanese IME text input prematurely submits the form

### DIFF
--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -65,7 +65,7 @@ export function ChatInput({
   }, [files])
 
   function onEnter(e: React.KeyboardEvent<HTMLFormElement>) {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault()
       if (e.currentTarget.checkValidity()) {
         handleSubmit(e)


### PR DESCRIPTION
## Description:

When using Japanese IME to input text, pressing the Enter key to confirm conversion would unintentionally submit the form. This pull request fixes the issue by utilizing the event.nativeEvent.isComposing property to prevent form submission while the IME conversion is still in progress.

## Specific changes:

	•	During the Enter key press event, the event.nativeEvent.isComposing is checked, and if IME conversion is ongoing, form submission is suppressed.
	•	Form submission now only occurs after IME input is fully confirmed.

## Reason for the fix:

This fix ensures that Japanese users can use the Enter key to confirm IME conversion without accidentally submitting the form, making the form interaction more intuitive and precise.

## Testing:

	•	Verified that pressing Enter during Japanese IME conversion does not submit the form.
	•	Confirmed that form submission works correctly with regular (non-IME) text input.