### PR TITLE
Fix chat input overflowing preview on smaller breakpoints

### DIFF
--- a/components/preview.tsx
+++ b/components/preview.tsx
@@ -1,6 +1,6 @@
+import { DeployDialog } from './deploy-dialog'
 import { FragmentCode } from './fragment-code'
 import { FragmentPreview } from './fragment-preview'
-import { DeployDialog } from './deploy-dialog'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
@@ -41,7 +41,7 @@ export function Preview({
   const isLinkAvailable = result?.template !== 'code-interpreter-v1'
 
   return (
-    <div className="absolute md:relative top-0 left-0 shadow-2xl md:rounded-tl-3xl md:rounded-bl-3xl md:border-l md:border-y bg-popover h-full w-full overflow-auto">
+    <div className="absolute md:relative z-10 top-0 left-0 shadow-2xl md:rounded-tl-3xl md:rounded-bl-3xl md:border-l md:border-y bg-popover h-full w-full overflow-auto">
       <Tabs
         value={selectedTab}
         onValueChange={(value) =>


### PR DESCRIPTION
This pr adds a z-index to the preview components, to account for the set z-index on the chat input components & overlay it on smaller breakpoints