### PR TITLE
Improves rate-limit recognition for Anthropic

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -67,7 +67,8 @@ export async function POST(req: Request) {
 
     return stream.toTextStreamResponse()
   } catch (error: any) {
-    const isRateLimitError = error && error.statusCode === 429
+    const isRateLimitError =
+      error && (error.statusCode === 429 || error.message.includes('limit'))
     const isOverloadedError =
       error && (error.statusCode === 529 || error.statusCode === 503)
     const isAccessDeniedError =


### PR DESCRIPTION
Anthropic for some reason sends 400 status code for request when billing quota was reached, I have added parsing the error message as well to detect anything that could contain limit.

<img width="693" alt="Screenshot 2025-03-24 at 23 44 50" src="https://github.com/user-attachments/assets/943180a1-c0f6-46fc-99ba-4a85b6d24613" />
