### PR TITLE
Add claude-opus-4-1-20250805 to model list

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -85,17 +85,17 @@
       "multiModal": true
     },
     {
-      "id": "claude-opus-4-20250514",
-      "provider": "Anthropic",
-      "providerId": "anthropic",
-      "name": "Claude Opus 4",
-      "multiModal": true
-    },
-    {
       "id": "claude-opus-4-1-20250805",
       "provider": "Anthropic",
       "providerId": "anthropic",
       "name": "Claude Opus 4.1",
+      "multiModal": true
+    },
+    {
+      "id": "claude-opus-4-20250514",
+      "provider": "Anthropic",
+      "providerId": "anthropic",
+      "name": "Claude Opus 4",
       "multiModal": true
     },
     {

--- a/lib/models.json
+++ b/lib/models.json
@@ -92,6 +92,13 @@
       "multiModal": true
     },
     {
+      "id": "claude-opus-4-1-20250805",
+      "provider": "Anthropic",
+      "providerId": "anthropic",
+      "name": "Claude Opus 4.1",
+      "multiModal": true
+    },
+    {
       "id": "claude-sonnet-4-20250514",
       "provider": "Anthropic",
       "providerId": "anthropic",


### PR DESCRIPTION
Add Claude Opus 4.1 model to the list of available models.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bca2271-e93b-4227-97ff-1527e7b4732a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bca2271-e93b-4227-97ff-1527e7b4732a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

