### PR TITLE
Add gpt-oss-120b to openai models

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -22,6 +22,13 @@
       "multiModal": true
     },
     {
+      "id": "gpt-oss-120b",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT OSS 120B",
+      "multiModal": true
+    },
+    {
       "id": "gpt-4.1",
       "provider": "OpenAI",
       "providerId": "openai",
@@ -82,13 +89,6 @@
       "provider": "OpenAI",
       "providerId": "openai",
       "name": "GPT-4 Turbo",
-      "multiModal": true
-    },
-    {
-      "id": "gpt-oss-120b",
-      "provider": "OpenAI",
-      "providerId": "openai",
-      "name": "GPT OSS 120B",
       "multiModal": true
     },
     {

--- a/lib/models.json
+++ b/lib/models.json
@@ -22,13 +22,6 @@
       "multiModal": true
     },
     {
-      "id": "gpt-oss-120b",
-      "provider": "OpenAI",
-      "providerId": "openai",
-      "name": "GPT OSS 120B",
-      "multiModal": true
-    },
-    {
       "id": "gpt-4.1",
       "provider": "OpenAI",
       "providerId": "openai",
@@ -285,6 +278,13 @@
       "provider": "Groq",
       "providerId": "groq",
       "name": "Llama 3.3 70B (Preview)",
+      "multiModal": false
+    },
+    {
+      "id": "gpt-oss-120b",
+      "provider": "Fireworks",
+      "providerId": "fireworks",
+      "name": "GPT OSS 120B",
       "multiModal": false
     },
     {

--- a/lib/models.json
+++ b/lib/models.json
@@ -281,7 +281,7 @@
       "multiModal": false
     },
     {
-      "id": "gpt-oss-120b",
+      "id": "accounts/fireworks/models/gpt-oss-120b",
       "provider": "Fireworks",
       "providerId": "fireworks",
       "name": "GPT OSS 120B",

--- a/lib/models.json
+++ b/lib/models.json
@@ -85,6 +85,13 @@
       "multiModal": true
     },
     {
+      "id": "gpt-oss-120b",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT OSS 120B",
+      "multiModal": true
+    },
+    {
       "id": "claude-opus-4-1-20250805",
       "provider": "Anthropic",
       "providerId": "anthropic",


### PR DESCRIPTION
Add `gpt-oss-120b` to OpenAI models in `lib/models.json` as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-637e872d-f9a6-4dc2-9415-734758470bd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-637e872d-f9a6-4dc2-9415-734758470bd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

