### PR TITLE
Add new gpt-5 models to open list

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,10 @@
 import { Duration } from '@/lib/duration'
-import { getModelClient } from '@/lib/models'
-import { LLMModel, LLMModelConfig } from '@/lib/models'
+import {
+  getModelClient,
+  getDefaultModelParams,
+  LLMModel,
+  LLMModelConfig,
+} from '@/lib/models'
 import { toPrompt } from '@/lib/prompt'
 import ratelimit from '@/lib/ratelimit'
 import { fragmentSchema as schema } from '@/lib/schema'
@@ -69,6 +73,7 @@ export async function POST(req: Request) {
       messages,
       maxRetries: 0, // do not retry on errors
       ...modelParams,
+      ...getDefaultModelParams(model),
     })
 
     return stream.toTextStreamResponse()

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -72,8 +72,8 @@ export async function POST(req: Request) {
       system: toPrompt(template),
       messages,
       maxRetries: 0, // do not retry on errors
-      ...modelParams,
       ...getDefaultModelParams(model),
+      ...modelParams,
     })
 
     return stream.toTextStreamResponse()

--- a/lib/models.json
+++ b/lib/models.json
@@ -1,6 +1,34 @@
 {
   "models": [
     {
+      "id": "gpt-5",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-5",
+      "multiModal": true
+    },
+    {
+      "id": "gpt-5-mini",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-5 Mini",
+      "multiModal": true
+    },
+    {
+      "id": "gpt-5-nano",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-5 Nano",
+      "multiModal": true
+    },
+    {
+      "id": "gpt-5-chat",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-5 Chat",
+      "multiModal": true
+    },
+    {
       "id": "o3",
       "provider": "OpenAI",
       "providerId": "openai",

--- a/lib/models.json
+++ b/lib/models.json
@@ -22,13 +22,6 @@
       "multiModal": true
     },
     {
-      "id": "gpt-5-chat",
-      "provider": "OpenAI",
-      "providerId": "openai",
-      "name": "GPT-5 Chat",
-      "multiModal": true
-    },
-    {
       "id": "o3",
       "provider": "OpenAI",
       "providerId": "openai",

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -84,7 +84,7 @@ export function getModelClient(model: LLMModel, config: LLMModelConfig) {
 export function getDefaultModelParams(model: LLMModel) {
   const { id: modelNameString } = model
 
-  if (['gpt-5', 'gpt-5-mini', 'gpt-5-nano'].includes(modelNameString)) {
+  if (modelNameString.startsWith('gpt-5')) {
     return {
       temperature: 1,
     }

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,10 +1,10 @@
 import { createAnthropic } from '@ai-sdk/anthropic'
+import { createFireworks } from '@ai-sdk/fireworks'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createVertex } from '@ai-sdk/google-vertex'
 import { createMistral } from '@ai-sdk/mistral'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createOllama } from 'ollama-ai-provider'
-import { createFireworks } from '@ai-sdk/fireworks'
 
 export type LLMModel = {
   id: string
@@ -79,4 +79,16 @@ export function getModelClient(model: LLMModel, config: LLMModelConfig) {
   }
 
   return createClient()
+}
+
+export function getDefaultModelParams(model: LLMModel) {
+  const { id: modelNameString } = model
+
+  if (['gpt-5', 'gpt-5-mini', 'gpt-5-nano'].includes(modelNameString)) {
+    return {
+      temperature: 1,
+    }
+  }
+
+  return {}
 }


### PR DESCRIPTION
Add gpt-5, gpt-5-mini, gpt-5-nano, and gpt-5-chat models to the top of the `models.json` list to make them available in the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-95a50da8-d6e4-4cd6-b82e-e89d8b52194f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95a50da8-d6e4-4cd6-b82e-e89d8b52194f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

