### PR TITLE
Add GPT-3.5 Turbo model support

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -106,6 +106,13 @@
       "multiModal": true
     },
     {
+      "id": "gpt-3.5-turbo",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-3.5 Turbo",
+      "multiModal": false
+    },
+    {
       "id": "claude-opus-4-1-20250805",
       "provider": "Anthropic",
       "providerId": "anthropic",


### PR DESCRIPTION
## Summary
- Added GPT-3.5 Turbo to the available models list
- Configured with OpenAI provider and appropriate settings
- Set multiModal to false as GPT-3.5 Turbo doesn't support multi-modal inputs

## Changes
- Updated `lib/models.json` to include GPT-3.5 Turbo model configuration

## Test plan
- [x] Validated JSON syntax is correct
- [x] Ran linting checks (passed)
- [x] Verified model follows existing pattern for OpenAI models

🤖 Generated with [Claude Code](https://claude.ai/code)