### PR TITLE
Add GPT-3.5 Turbo model support

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -99,6 +99,13 @@
       "multiModal": false
     },
     {
+      "id": "gpt-3.5-turbo",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-3.5 Turbo",
+      "multiModal": false
+    },
+    {
       "id": "gpt-4-turbo",
       "provider": "OpenAI",
       "providerId": "openai",


### PR DESCRIPTION
## Summary

This PR adds GPT-3.5 Turbo to the list of available models in the Fragments application.

## Changes

- Added `gpt-3.5-turbo` model entry to `lib/models.json`
- Set `multiModal: false` as GPT-3.5 Turbo doesn't support multimodal inputs
- Positioned between o1-mini and gpt-4-turbo in the OpenAI models section
- Follows the existing model configuration pattern with proper provider settings

## Details

The new model entry includes:
- **ID**: `gpt-3.5-turbo` (matches OpenAI's official model name)
- **Provider**: `OpenAI`
- **Provider ID**: `openai` 
- **Name**: `GPT-3.5 Turbo` (user-friendly display name)
- **Multimodal**: `false` (GPT-3.5 Turbo is text-only)

This addition allows users to select and use GPT-3.5 Turbo as one of the available AI models in the Fragments application. The existing OpenAI provider configuration in `models.ts` will automatically handle this new model since it uses the same `openai` provider ID.

## Test plan

- [x] Validated JSON syntax is correct
- [x] Ran linting checks (passed)
- [x] Ran build process (successful)
- [x] Verified model follows existing pattern for OpenAI models
- [x] Confirmed existing provider configuration supports this model

🤖 Generated with [Claude Code](https://claude.ai/code)