### PR TITLE
Add GPT-3.5-Turbo model support

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -106,6 +106,13 @@
       "multiModal": true
     },
     {
+      "id": "gpt-3.5-turbo",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-3.5 Turbo",
+      "multiModal": false
+    },
+    {
       "id": "claude-opus-4-1-20250805",
       "provider": "Anthropic",
       "providerId": "anthropic",


### PR DESCRIPTION
## Summary
- Added `gpt-3.5-turbo` model to the model configuration
- Configured with OpenAI provider (`openai`)
- Set `multiModal` to `false` as GPT-3.5-Turbo doesn't support image inputs

## Changes
- Updated `lib/models.json` to include the new GPT-3.5-Turbo model entry

## Test plan
- [x] Verified JSON syntax is valid
- [x] Ensured model follows existing OpenAI model patterns
- [x] Confirmed multiModal setting is appropriate for GPT-3.5-Turbo capabilities

🤖 Generated with [Claude Code](https://claude.ai/code)