### PR TITLE
Add GPT-3.5 Turbo model support

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -99,6 +99,13 @@
       "multiModal": false
     },
     {
+      "id": "gpt-3.5-turbo",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-3.5 Turbo",
+      "multiModal": false
+    },
+    {
       "id": "gpt-4-turbo",
       "provider": "OpenAI",
       "providerId": "openai",


### PR DESCRIPTION
## Summary
- Added GPT-3.5 Turbo to the available models list
- Configured with OpenAI provider
- Set multiModal to false (GPT-3.5 Turbo doesn't support multimodal input)

## Changes
- Added new model entry in `lib/models.json` with:
  - Model ID: `gpt-3.5-turbo`
  - Provider: OpenAI
  - Multimodal: false

This enables users to select GPT-3.5 Turbo as their model choice in the fragments application.

## Test plan
- [x] Verified JSON syntax is valid
- [ ] Manual testing of model selection in the UI
- [ ] Verify API calls work with the new model

🤖 Generated with [Claude Code](https://claude.ai/code)