### PR TITLE
Add GPT-3.5-Turbo model support

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -106,6 +106,13 @@
       "multiModal": true
     },
     {
+      "id": "gpt-3.5-turbo",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-3.5-Turbo",
+      "multiModal": false
+    },
+    {
       "id": "claude-opus-4-1-20250805",
       "provider": "Anthropic",
       "providerId": "anthropic",


### PR DESCRIPTION
## Summary

• Added GPT-3.5-Turbo to the available models list in models.json
• Provides users with access to this cost-effective OpenAI model option
• No breaking changes - purely additive enhancement

## Test plan

- [x] Verified the model configuration follows existing patterns
- [x] Confirmed the build passes successfully
- [x] Tested lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)