### PR TITLE
Add security headers to Next.js configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,18 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+        ],
+      }
+    ]
+  },
+}
 
 export default nextConfig


### PR DESCRIPTION
Adds security headers to prevent iframe-based clickjacking attacks by setting `X-Frame-Options: DENY` on all routes.

## Changes
- Configured Next.js to return `X-Frame-Options: DENY` header for all routes
- Prevents the application from being embedded in iframes, frames, or object elements