### PR TITLE
Improved reactivity in Fragments

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -165,9 +165,7 @@ export default function Home() {
           content,
           object,
         })
-      }
-
-      if (lastMessage && lastMessage.role === 'assistant') {
+      } else if (lastMessage && lastMessage.role === 'assistant') {
         setLastMessage({
           content,
           object,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,11 +77,16 @@ export default function Home() {
 
   const lastMessage = useMemo(() => messages[messages.length - 1], [messages])
 
-  const setLastMessage = useCallback((message: Message) => {
-    setMessages((previousMessages) => [
-      ...previousMessages.slice(0, -1),
-      message,
-    ])
+  const setLastMessage = useCallback((updates: Partial<Message>) => {
+    setMessages((previousMessages) => {
+      const lastMessage = previousMessages[previousMessages.length - 1]
+      if (!lastMessage) return previousMessages
+      
+      return [
+        ...previousMessages.slice(0, -1),
+        { ...lastMessage, ...updates },
+      ]
+    })
   }, [])
 
   const currentTemplate = useMemo(
@@ -139,6 +144,7 @@ export default function Home() {
 
         setResult(result)
         setCurrentPreview({ fragment, result })
+        setLastMessage({ result })
         setCurrentTab('fragment')
         setIsPreviewLoading(false)
       }
@@ -163,7 +169,6 @@ export default function Home() {
 
       if (lastMessage && lastMessage.role === 'assistant') {
         setLastMessage({
-          role: 'assistant',
           content,
           object,
         })

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,8 +47,6 @@ export default function Home() {
   const [messages, setMessages] = useState<Message[]>([])
   const [fragment, setFragment] = useState<DeepPartial<FragmentSchema>>()
   const [isSideBarOpen, setIsSideBarOpen] = useState(false)
-  const [currentFragment, setCurrentFragment] =
-    useState<DeepPartial<FragmentSchema>>()
   const [currentTab, setCurrentTab] = useState<'code' | 'fragment'>('code')
   const [isPreviewLoading, setIsPreviewLoading] = useState(false)
   const [isAuthDialogOpen, setAuthDialog] = useState(false)
@@ -96,8 +94,8 @@ export default function Home() {
 
   // Determine which API to use based on morph toggle and existing fragment
   const shouldUseMorph = useMemo(
-    () => useMorphApply && currentFragment,
-    [useMorphApply, currentFragment],
+    () => useMorphApply && fragment,
+    [useMorphApply, fragment],
   )
 
   const apiEndpoint = useMemo(
@@ -141,7 +139,6 @@ export default function Home() {
 
         setResult(result)
         setCurrentPreview({ fragment, result })
-        setCurrentFragment(fragment)
         setCurrentTab('fragment')
         setIsPreviewLoading(false)
       }
@@ -210,7 +207,7 @@ export default function Home() {
       template: currentTemplate,
       model: currentModel,
       config: languageModel,
-      ...(shouldUseMorph ? { currentFragment } : {}),
+      ...(shouldUseMorph ? { currentFragment: fragment } : {}),
     })
 
     setChatInput('')
@@ -232,7 +229,7 @@ export default function Home() {
       template: currentTemplate,
       model: currentModel,
       config: languageModel,
-      ...(shouldUseMorph ? { currentFragment } : {}),
+      ...(shouldUseMorph ? { currentFragment: fragment } : {}),
     })
   }
 
@@ -277,7 +274,6 @@ export default function Home() {
     setFiles([])
     setMessages([])
     setFragment(undefined)
-    setCurrentFragment(undefined)
     setResult(undefined)
     setCurrentTab('code')
     setIsPreviewLoading(false)

--- a/components/preview.tsx
+++ b/components/preview.tsx
@@ -24,7 +24,8 @@ export function Preview({
   isPreviewLoading,
   fragment,
   result,
-  onClose,
+  isSideBarOpen,
+  setIsSideBarOpen,
 }: {
   teamID: string | undefined
   accessToken: string | undefined
@@ -34,9 +35,10 @@ export function Preview({
   isPreviewLoading: boolean
   fragment?: DeepPartial<FragmentSchema>
   result?: ExecutionResult
-  onClose: () => void
+  isSideBarOpen: boolean
+  setIsSideBarOpen: Dispatch<SetStateAction<boolean>>
 }) {
-  if (!fragment) {
+  if (!isSideBarOpen) {
     return null
   }
 
@@ -59,7 +61,7 @@ export function Preview({
                   variant="ghost"
                   size="icon"
                   className="text-muted-foreground"
-                  onClick={onClose}
+                  onClick={() => setIsSideBarOpen(false)}
                 >
                   <ChevronsRight className="h-5 w-5" />
                 </Button>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Memoizes key selectors and introduces an independently toggleable preview sidebar, updating API selection, message updates, and layout accordingly.
> 
> - **UI/UX**:
>   - Preview sidebar made independently toggleable via `isSideBarOpen`; open on submit/preview, close via button; layout switches between `md:grid-cols-1` and `md:grid-cols-2`.
>   - `Preview` now renders based on `isSideBarOpen` (not `fragment`), replacing `onClose` with `isSideBarOpen` and `setIsSideBarOpen`.
> - **State & Performance**:
>   - Memoized `filteredModels`, `currentModel`, `lastMessage`, `currentTemplate`, `shouldUseMorph`, and `apiEndpoint` using `useMemo`.
>   - Added `setLastMessage` (`useCallback`) and removed `setMessage`, updating assistant message/result updates accordingly.
> - **Behavior**:
>   - Simplified morph usage: `shouldUseMorph` now checks only `fragment`; conditional payload spread updated to `...(shouldUseMorph ? { currentFragment: fragment } : {})`.
>   - Always opens sidebar when submitting or setting current preview.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a66a4ff0ce0aa2928ac8b45ee32fb72b4926b691. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->