### PR TITLE
fix: add missing nanoid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dotenv": "^17.2.0",
     "e2b": "^2.3.0",
     "lucide-react": "^0.396.0",
+    "nanoid": "^5.1.6",
     "next": "^14.2.32",
     "next-themes": "^0.3.0",
     "ollama-ai-provider": "^1.2.0",


### PR DESCRIPTION
Added missing `nanoid` dependency - without it, the app crashes