### PR TITLE
Remove specified AI models

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,7 +31,7 @@ export default function Home() {
   const [languageModel, setLanguageModel] = useLocalStorage<LLMModelConfig>(
     'languageModel',
     {
-      model: 'claude-3-7-sonnet-latest',
+      model: 'claude-sonnet-4-20250514',
     },
   )
 
@@ -59,9 +59,20 @@ export default function Home() {
     return true
   })
 
+  const defaultModel = filteredModels.find(
+    (model) => model.id === 'claude-sonnet-4-20250514',
+  ) || filteredModels[0]
+
   const currentModel = filteredModels.find(
     (model) => model.id === languageModel.model,
-  )
+  ) || defaultModel
+
+  // Update localStorage if stored model no longer exists
+  useEffect(() => {
+    if (languageModel.model && !filteredModels.find((m) => m.id === languageModel.model)) {
+      setLanguageModel({ ...languageModel, model: defaultModel.id })
+    }
+  }, [languageModel.model])
   const currentTemplate =
     selectedTemplate === 'auto'
       ? templates

--- a/lib/models.json
+++ b/lib/models.json
@@ -99,6 +99,20 @@
       "multiModal": true
     },
     {
+      "id": "claude-opus-4-5-20251101",
+      "provider": "Anthropic",
+      "providerId": "anthropic",
+      "name": "Claude Opus 4.5",
+      "multiModal": true
+    },
+    {
+      "id": "claude-haiku-4-5-20251001",
+      "provider": "Anthropic",
+      "providerId": "anthropic",
+      "name": "Claude Haiku 4.5",
+      "multiModal": true
+    },
+    {
       "id": "claude-sonnet-4-5-20250929",
       "provider": "Anthropic",
       "providerId": "anthropic",
@@ -124,13 +138,6 @@
       "provider": "Anthropic",
       "providerId": "anthropic",
       "name": "Claude Sonnet 4",
-      "multiModal": true
-    },
-    {
-      "id": "claude-3-7-sonnet-latest",
-      "provider": "Anthropic",
-      "providerId": "anthropic",
-      "name": "Claude Sonnet 3.7",
       "multiModal": true
     },
     {


### PR DESCRIPTION
Remove `o1`, `claude-3-5-sonnet-latest`, and `gemini-1.5-pro` models and set `claude-3-7-sonnet-latest` as the new default.

---
<a href="https://cursor.com/background-agent?bcId=bc-e662a4cb-59a7-4073-8189-55d4b5bf5ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e662a4cb-59a7-4073-8189-55d4b5bf5ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `claude-sonnet-4-20250514` as the default, adds fallback/sync logic for missing models, and refreshes `lib/models.json` (removes `o1` and Gemini 1.5 Pro; updates Anthropic 4.x IDs/names).
> 
> - **Frontend (`app/page.tsx`)**:
>   - Default `languageModel.model` changed to `claude-sonnet-4-20250514`.
>   - Added `defaultModel` selection and fallback for `currentModel`.
>   - Added `useEffect` to reset stored model if it no longer exists in filtered list.
> - **Models (`lib/models.json`)**:
>   - Removed OpenAI `o1` and Google Gemini 1.5 Pro entries.
>   - Updated Anthropic lineup: replaced older Claude entries with 4.x variants and revised IDs/names (Opus/Sonnet/Haiku).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 295da5dcffb7eaaf02695542e9a05958fbb7e1c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->