### PR TITLE
fix: sidebar state on morph-apply

### DIFF
--- a/app/api/morph-chat/route.ts
+++ b/app/api/morph-chat/route.ts
@@ -30,6 +30,14 @@ export async function POST(req: Request) {
     currentFragment: FragmentSchema
   } = await req.json()
 
+  // Validate that currentFragment exists (required for morph edits)
+  if (!currentFragment?.file_path || !currentFragment?.code) {
+    return new Response(
+      JSON.stringify({ error: 'currentFragment with file_path and code is required for morph edits' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
   // Rate limiting (same as chat route)
   const limit = !config.apiKey
     ? await ratelimit(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -126,7 +126,8 @@ export default function Home() {
   })
 
   useEffect(() => {
-    if (object) {
+    // Only update messages during active streaming, not when toggling settings
+    if (object && isLoading) {
       setFragment(object)
       const content: Message['content'] = [
         { type: 'text', text: object.commentary || '' },
@@ -148,7 +149,7 @@ export default function Home() {
         })
       }
     }
-  }, [object])
+  }, [object, isLoading])
 
   useEffect(() => {
     if (error) stop()

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -79,8 +79,8 @@ export default function Home() {
       : { [selectedTemplate]: templates[selectedTemplate] }
   const lastMessage = messages[messages.length - 1]
 
-  // Determine which API to use based on morph toggle
-  const apiEndpoint = useMorphApply ? '/api/morph-chat' : '/api/chat'
+  // Determine which API to use based on morph toggle AND whether we have a fragment to edit
+  const apiEndpoint = useMorphApply && fragment?.code ? '/api/morph-chat' : '/api/chat'
 
   const { object, submit, isLoading, stop, error } = useObject({
     api: apiEndpoint,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -79,10 +79,8 @@ export default function Home() {
       : { [selectedTemplate]: templates[selectedTemplate] }
   const lastMessage = messages[messages.length - 1]
 
-  // Determine which API to use based on morph toggle and existing fragment
-  const shouldUseMorph =
-    useMorphApply && fragment && fragment.code && fragment.file_path
-  const apiEndpoint = shouldUseMorph ? '/api/morph-chat' : '/api/chat'
+  // Determine which API to use based on morph toggle
+  const apiEndpoint = useMorphApply ? '/api/morph-chat' : '/api/chat'
 
   const { object, submit, isLoading, stop, error } = useObject({
     api: apiEndpoint,
@@ -200,7 +198,7 @@ export default function Home() {
       template: currentTemplate,
       model: currentModel,
       config: languageModel,
-      ...(shouldUseMorph && fragment ? { currentFragment: fragment } : {}),
+      ...(useMorphApply && fragment?.code ? { currentFragment: fragment } : {}),
     })
 
     setChatInput('')
@@ -221,7 +219,7 @@ export default function Home() {
       template: currentTemplate,
       model: currentModel,
       config: languageModel,
-      ...(shouldUseMorph && fragment ? { currentFragment: fragment } : {}),
+      ...(useMorphApply && fragment?.code ? { currentFragment: fragment } : {}),
     })
   }
 


### PR DESCRIPTION
Fixes sidebar state getting broken whilst switching to "morph apply" - ie. sidebar cant be closed when using morph apply feature.

The way this works is basically by decoupling the sidebar state from the API route - thus preventing unwanted reloads and re-renders caused by side-effects.