### PR TITLE
fix(ui): chat disabled when using own api key

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -319,6 +319,7 @@ export default function Home() {
             errorMessage={errorMessage}
             isLoading={isLoading}
             isRateLimited={isRateLimited}
+            hasUserApiKey={!!languageModel.apiKey}
             stop={stop}
             input={chatInput}
             handleInputChange={handleSaveInputChange}

--- a/components/chat-input.tsx
+++ b/components/chat-input.tsx
@@ -19,6 +19,7 @@ export function ChatInput({
   errorMessage,
   isLoading,
   isRateLimited,
+  hasUserApiKey,
   stop,
   input,
   handleInputChange,
@@ -33,6 +34,7 @@ export function ChatInput({
   errorMessage: string
   isLoading: boolean
   isRateLimited: boolean
+  hasUserApiKey: boolean
   stop: () => void
   input: string
   handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
@@ -189,7 +191,7 @@ export function ChatInput({
             className="text-normal px-3 resize-none ring-0 bg-inherit w-full m-0 outline-none"
             required={true}
             placeholder="Describe your app..."
-            disabled={isErrored}
+            disabled={isErrored && !(isRateLimited && hasUserApiKey)}
             value={input}
             onChange={handleInputChange}
             onPaste={isMultiModal ? handlePaste : undefined}
@@ -209,7 +211,7 @@ export function ChatInput({
                 <Tooltip delayDuration={0}>
                   <TooltipTrigger asChild>
                     <Button
-                      disabled={!isMultiModal || isErrored}
+                      disabled={!isMultiModal || (isErrored && !(isRateLimited && hasUserApiKey))}
                       type="button"
                       variant="outline"
                       size="icon"
@@ -233,7 +235,7 @@ export function ChatInput({
                   <Tooltip delayDuration={0}>
                     <TooltipTrigger asChild>
                       <Button
-                        disabled={isErrored}
+                        disabled={isErrored && !(isRateLimited && hasUserApiKey)}
                         variant="default"
                         size="icon"
                         type="submit"


### PR DESCRIPTION
Solves issue when user is rate-limited and then switches to their own API key - before the fix the input stayed disabled, now it can be used again after providing the API key.