### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   validate-renovate-config:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/e2b-dev/fragments/security/code-scanning/3](https://github.com/e2b-dev/fragments/security/code-scanning/3)

In general, to fix this type of issue you explicitly declare a `permissions` block for the workflow or individual job(s), granting only the specific scopes and access levels needed. For read-only validation or CI jobs that do not modify repository data or GitHub resources, this typically means `contents: read` (and occasionally other read scopes if needed).

For this specific workflow, the `validate-renovate-config` job only checks out the repository and runs `github-action-renovate-config-validator`, which reads Renovate configuration files but does not need to write to the repo or interact with issues/PRs. The safest and least-privilege fix is to add a `permissions` block at the job level, directly under `runs-on`, setting `contents: read`. This avoids changing behavior while constraining `GITHUB_TOKEN`. No imports or external dependencies are involved, as this is a YAML workflow configuration, not application code.

Concretely:
- Edit `.github/workflows/validate-renovate-config.yaml`.
- Under `jobs.validate-renovate-config.runs-on: ubuntu-24.04`, add:

  ```yaml
      permissions:
        contents: read
  ```

This limits the job’s `GITHUB_TOKEN` to read-only repository contents, which is sufficient for checkout and validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that tightens GitHub Actions token permissions without altering build logic or production code paths.
> 
> **Overview**
> Adds an explicit **least-privilege** `permissions` block to the `validate-renovate-config` GitHub Actions job, limiting `GITHUB_TOKEN` to `contents: read` while validating the Renovate configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2873999f1323365cfa4ff5a522278f6d5bd36869. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->