### PR TITLE
Add GPT-3.5 Turbo to models list

### DIFF
--- a/lib/models.json
+++ b/lib/models.json
@@ -99,6 +99,13 @@
       "multiModal": true
     },
     {
+      "id": "gpt-3.5-turbo",
+      "provider": "OpenAI",
+      "providerId": "openai",
+      "name": "GPT-3.5 Turbo",
+      "multiModal": false
+    },
+    {
       "id": "claude-opus-4-5-20251101",
       "provider": "Anthropic",
       "providerId": "anthropic",


### PR DESCRIPTION
## Summary
- Adds `gpt-3.5-turbo` (GPT-3.5 Turbo) as an OpenAI model option in `lib/models.json`
- Set `multiModal` to `false` as GPT-3.5 Turbo does not support image inputs

## Test plan
- [ ] Verify GPT-3.5 Turbo appears in the model picker dropdown under the OpenAI provider
- [ ] Confirm chat works end-to-end with GPT-3.5 Turbo selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)