### PR TITLE
feat: add Google Tag Manager (NEXT_PUBLIC_GTM_ID)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -43,3 +43,6 @@ NEXT_PUBLIC_POSTHOG_HOST=
 
 # Hide local models from the list of available models
 # NEXT_PUBLIC_HIDE_LOCAL_MODELS=
+
+# Google Tag Manager container ID (set in the deploy environment)
+NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css'
 import { PostHogProvider, ThemeProvider } from './providers'
 import { Toaster } from '@/components/ui/toaster'
 import { Analytics } from '@vercel/analytics/next'
+import { GoogleTagManager } from '@next/third-parties/google'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 
@@ -19,6 +20,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      {process.env.NEXT_PUBLIC_GTM_ID && (
+        <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
+      )}
       <PostHogProvider>
         <body className={inter.className}>
           <ThemeProvider

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@ai-sdk/mistral": "^1.0.1",
         "@ai-sdk/openai": "^1.3.24",
         "@e2b/code-interpreter": "^1.0.2",
+        "@next/third-parties": "^14.2.35",
         "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
@@ -1865,6 +1866,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.2.35.tgz",
+      "integrity": "sha512-dG1J+4uYungW1snGViN7tAVyfO0iz0zoB+sqsLMUo8kwR0NED2muLTMbOChmrliHhzOFj6ZpHfkvhy5NJjFvSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -10243,6 +10257,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/throttleit": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@ai-sdk/mistral": "^1.0.1",
     "@ai-sdk/openai": "^1.3.24",
     "@e2b/code-interpreter": "^1.0.2",
+    "@next/third-parties": "^14.2.35",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",


### PR DESCRIPTION
Adds Google Tag Manager to the demo app, loaded via `@next/third-parties/google` and gated on `NEXT_PUBLIC_GTM_ID` so it only loads when the container ID is set (no-op locally / in forks).

**Deploy step:** set `NEXT_PUBLIC_GTM_ID=<shared GTM container id>` in the Vercel project env, then redeploy. Coexists with the existing Vercel Analytics + PostHog.