### PR TITLE
fix(sandbox): replace forEach(async) with Promise.all to prevent race condition on multi-file writes

### DIFF
--- a/app/api/sandbox/route.ts
+++ b/app/api/sandbox/route.ts
@@ -50,10 +50,12 @@ export async function POST(req: Request) {
 
   // Copy code to fs
   if (fragment.code && Array.isArray(fragment.code)) {
-    fragment.code.forEach(async (file) => {
-      await sbx.files.write(file.file_path, file.file_content)
-      console.log(`Copied file to ${file.file_path} in ${sbx.sandboxId}`)
-    })
+    await Promise.all(
+      fragment.code.map(async (file) => {
+        await sbx.files.write(file.file_path, file.file_content)
+        console.log(`Copied file to ${file.file_path} in ${sbx.sandboxId}`)
+      }),
+    )
   } else {
     await sbx.files.write(fragment.file_path, fragment.code)
     console.log(`Copied file to ${fragment.file_path} in ${sbx.sandboxId}`)


### PR DESCRIPTION
## Summary

Fixes #229.

Resolves a race condition in the sandbox API route where `sbx.runCode()` could
be invoked before all sandbox file writes had completed, causing code execution
against a partially-written filesystem for multi-file fragments.

---

## Root Cause

In `app/api/sandbox/route.ts`, the multi-file write path used:

```ts
fragment.code.forEach(async (file) => {
  await sbx.files.write(file.file_path, file.file_content)
  console.log(`Copied file to ${file.file_path} in ${sbx.sandboxId}`)
})