### PR TITLE
Fix race condition in sandbox multi-file writes

### DIFF
--- a/app/api/sandbox/route.ts
+++ b/app/api/sandbox/route.ts
@@ -50,10 +50,12 @@ export async function POST(req: Request) {
 
   // Copy code to fs
   if (fragment.code && Array.isArray(fragment.code)) {
-    fragment.code.forEach(async (file) => {
-      await sbx.files.write(file.file_path, file.file_content)
-      console.log(`Copied file to ${file.file_path} in ${sbx.sandboxId}`)
-    })
+    await Promise.all(
+      fragment.code.map(async (file) => {
+        await sbx.files.write(file.file_path, file.file_content)
+        console.log(`Copied file to ${file.file_path} in ${sbx.sandboxId}`)
+      }),
+    )
   } else {
     await sbx.files.write(fragment.file_path, fragment.code)
     console.log(`Copied file to ${fragment.file_path} in ${sbx.sandboxId}`)


### PR DESCRIPTION
## Problem
Multi-file fragments can execute before all files are written to the sandbox — a race condition in app/api/sandbox/route.ts.

Array.prototype.forEach ignores the promises returned by the async callback. The outer POST handler continues to sbx.runCode(...) / URL return without awaiting the writes.

## Fix
Replaced orEach(async) with wait Promise.all(fragment.code.map(...)) so all files are persisted before execution or URL return.

Closes #229