### PR TITLE
fix: correct 'Frequence penalty' label typo in chat settings

### DIFF
--- a/components/chat-settings.tsx
+++ b/components/chat-settings.tsx
@@ -192,7 +192,7 @@ export function ChatSettings({
           </div>
           <div className="flex space-x-4 items-center">
             <span className="text-sm flex-1 text-muted-foreground">
-              Frequence penalty
+              Frequency penalty
             </span>
             <Input
               type="number"


### PR DESCRIPTION
## Summary

Fix 1 typo in a user-facing UI label:

- **components/chat-settings.tsx** (line 195): `Frequence penalty` -> `Frequency penalty`

The label sits directly above the `frequencyPenalty` input, and the adjacent control on line 214 already reads "Presence penalty", so this is the odd one out. Only the display text inside the `<span>` changed - the `frequencyPenalty` property and every other identifier are untouched, so there are no functional changes.